### PR TITLE
fix: added quotes to $WM_CLASS and $WM_NAME

### DIFF
--- a/xxxwindow.sh
+++ b/xxxwindow.sh
@@ -11,11 +11,11 @@ elif [ $WM_DESKTOP != "1883" ]; then
 	WM_CLASS=$(xprop -id $(xdotool getactivewindow) WM_CLASS | awk 'NF {print $NF}' | sed 's/"/ /g')
 	WM_NAME=$(xprop -id $(xdotool getactivewindow) WM_NAME | cut -d '=' -f 2 | awk -F\" '{ print $2 }')
 
-	if [ $WM_CLASS == 'Enter WM_CLASS value here' ]; then
+	if [ "$WM_CLASS" == 'Enter WM_CLASS value here' ]; then
 
 		echo "%{F#ffffff}Custom name%{u-}"
 	
-	elif [ $WM_NAME == 'Enter WM_NAME value here' ]; then
+	elif [ "$WM_NAME" == 'Enter WM_NAME value here' ]; then
 
 		echo "%{F#ffffff}Custom name%{u-}"
 


### PR DESCRIPTION
if WM_CLASS or WM_NAME have spaces bash thinks its multiple strings resulting in an error. Quotes are used to force it to be a single string.